### PR TITLE
Unknown param type converter should return the Java delegate if possible

### DIFF
--- a/src/main/resources/vertx/util/utils.rb
+++ b/src/main/resources/vertx/util/utils.rb
@@ -29,6 +29,8 @@ module Vertx
           JsonObject.new(JSON.generate(object))
         elsif object.is_a? Array
           JsonArray.new(JSON.generate(object))
+        elsif object.respond_to?(:j_del)
+          object.j_del
         else
           # Best effort, we let jruby handle the conversion
           object

--- a/src/main/resources/vertx/util/utils.rb
+++ b/src/main/resources/vertx/util/utils.rb
@@ -11,12 +11,12 @@ module Vertx
       def self.from_throwable(err)
         begin
           raise_runtime_exception(err)
-        rescue Exception => e;
-          return e;
+        rescue Exception => e
+          return e
         end
       end
       def self.to_throwable(err)
-        Java::IoVertxLangRuby::Helper.catchAndReturnThrowable(Proc.new { raise err });
+        Java::IoVertxLangRuby::Helper.catchAndReturnThrowable(Proc.new {raise err})
       end
       def self.safe_create(object, clazz, *args)
         if nil != object
@@ -128,17 +128,17 @@ module Vertx
       end
       def self.to_handler_proc(handler, &converter)
         Proc.new { |val|
-          val = yield val;
-          handler.handle(val);
+          val = yield val
+          handler.handle(val)
         }
       end
       def self.to_async_result_handler_proc(handler, &converter)
         Proc.new { |err,val|
           if nil != err
-            handler.handle(Java::IoVertxLangRuby::Helper.failedResult(err));
+            handler.handle(Java::IoVertxLangRuby::Helper.failedResult(err))
           else
-            val = yield val;
-            handler.handle(Java::IoVertxLangRuby::Helper.succeededResult(val));
+            val = yield val
+            handler.handle(Java::IoVertxLangRuby::Helper.succeededResult(val))
           end
         }
       end
@@ -293,7 +293,7 @@ module Vertx
         JSON.parse(obj.toJson.encode)
       end
       def unwrap(obj)
-        @clazz.new(Utils.to_json_object(obj));
+        @clazz.new(Utils.to_json_object(obj))
       end
     end
     def self.data_object_type(clazz)

--- a/src/test/java/io/vertx/test/lang/ruby/EventBusTest.java
+++ b/src/test/java/io/vertx/test/lang/ruby/EventBusTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.test.lang.ruby;
+
+import org.junit.Test;
+
+/**
+ * @author Thomas Segismont
+ */
+public class EventBusTest extends RubyTestBase {
+
+  @Test
+  public void testSendBuffer() throws Exception {
+    runTest();
+  }
+
+  private void runTest() {
+    runTest("event_bus_test", testName.getMethodName());
+  }
+}

--- a/src/test/resources/api_tck_test.rb
+++ b/src/test/resources/api_tck_test.rb
@@ -131,7 +131,7 @@ def testMethodWithHandlerGenericReturn
   handler.call("the-result");
   Assert.equals(result, "the-result")
   handler.call(@obj);
-  Assert.equals(result, @obj)
+  Assert.equals(result, @obj.j_del)
 end
 
 def testMethodWithHandlerVertxGenReturn
@@ -173,7 +173,7 @@ def testMethodWithHandlerAsyncResultGenericReturn
   succeedingHandler.call(nil, "the-result");
   Assert.equals(result, "the-result")
   succeedingHandler.call(nil, @obj);
-  Assert.equals(result, @obj)
+  Assert.equals(result, @obj.j_del)
 end
 
 def testMethodWithHandlerAsyncResultVertxGenReturn

--- a/src/test/resources/api_tck_test.rb
+++ b/src/test/resources/api_tck_test.rb
@@ -19,11 +19,11 @@ java_import 'io.vertx.codegen.testmodel.RefedInterface1Impl'
 @refed_obj = Testmodel::RefedInterface1.new(RefedInterface1Impl.new)
 
 def testMethodWithBasicParams
-  @obj.method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar');
+  @obj.method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
 end
 
 def testMethodWithBasicBoxedParams
-  @obj.method_with_basic_boxed_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88);
+  @obj.method_with_basic_boxed_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88)
 end
 
 def testMethodWithHandlerBasicTypes
@@ -118,7 +118,7 @@ def testMethodWithHandlerStringReturn
   begin
     handler.call("unexpected")
   rescue Object => e
-    failed = true;
+    failed = true
   end
   Assert.equals(failed, true)
 end
@@ -128,16 +128,16 @@ def testMethodWithHandlerGenericReturn
   handler = @obj.method_with_handler_generic_return() { |val|
     result = val
   }
-  handler.call("the-result");
+  handler.call("the-result")
   Assert.equals(result, "the-result")
-  handler.call(@obj);
+  handler.call(@obj)
   Assert.equals(result, @obj.j_del)
 end
 
 def testMethodWithHandlerVertxGenReturn
   handler = @obj.method_with_handler_vertx_gen_return("the-result")
   @refed_obj.set_string('the-result')
-  handler.call(@refed_obj);
+  handler.call(@refed_obj)
 end
 
 def testMethodWithHandlerAsyncResultStringReturn
@@ -147,16 +147,16 @@ def testMethodWithHandlerAsyncResultStringReturn
   begin
     succeedingHandler.call(nil)
   rescue Object => e
-    failed = true;
+    failed = true
   end
   Assert.equals(failed, true)
   failingHandler = @obj.method_with_handler_async_result_string_return("an-error", true)
-  failingHandler.call("an-error");
+  failingHandler.call("an-error")
   failed = false
   begin
-    failingHandler.call(nil, "unexpected");
+    failingHandler.call(nil, "unexpected")
   rescue Object => e
-    failed = true;
+    failed = true
   end
   Assert.equals(failed, true)
 end
@@ -170,18 +170,18 @@ def testMethodWithHandlerAsyncResultGenericReturn
       result = err
     end
   }
-  succeedingHandler.call(nil, "the-result");
+  succeedingHandler.call(nil, "the-result")
   Assert.equals(result, "the-result")
-  succeedingHandler.call(nil, @obj);
+  succeedingHandler.call(nil, @obj)
   Assert.equals(result, @obj.j_del)
 end
 
 def testMethodWithHandlerAsyncResultVertxGenReturn
   handler = @obj.method_with_handler_async_result_vertx_gen_return("the-async-result", false)
   @refed_obj.set_string('the-async-result')
-  handler.call(nil, @refed_obj);
+  handler.call(nil, @refed_obj)
   handler = @obj.method_with_handler_async_result_vertx_gen_return("the-async-failure", true)
-  handler.call("the-async-failure", nil);
+  handler.call("the-async-failure", nil)
 end
 
 def testMethodWithHandlerUserTypes

--- a/src/test/resources/assert.rb
+++ b/src/test/resources/assert.rb
@@ -42,7 +42,7 @@ module Assert
   def self.argument_error(&callback)
     failed = false
     begin
-      callback.call;
+      callback.call
     rescue ArgumentError
       failed = true
     end

--- a/src/test/resources/event_bus_test.rb
+++ b/src/test/resources/event_bus_test.rb
@@ -1,0 +1,23 @@
+require 'java'
+require 'assert'
+require 'vertx/vertx'
+require 'vertx/buffer'
+
+java_import 'java.util.concurrent.CountDownLatch'
+java_import 'java.util.concurrent.TimeUnit'
+
+def testSendBuffer
+  vertx = Vertx::Vertx.vertx
+  latch = CountDownLatch.new(1)
+
+  event_bus = vertx.event_bus
+  event_bus.consumer('foo') do |msg|
+    Assert.equals('The quick brown fox jumps over the lazy dog', msg.body.to_string)
+    latch.countDown
+  end.completion_handler() do |err, v|
+    Assert.is_nil(err)
+    event_bus.send('foo', Vertx::Buffer.buffer('The quick brown fox jumps over the lazy dog'))
+  end
+
+  Assert.equals(latch.await(2, TimeUnit::MINUTES), true)
+end

--- a/src/test/resources/generics_tck_test.rb
+++ b/src/test/resources/generics_tck_test.rb
@@ -497,7 +497,7 @@ def checkMethodWithClassType values
 end
 
 def testInterfaceWithStringArg
-  ret = @obj.interface_with_string_arg('the_string_value');
+  ret = @obj.interface_with_string_arg('the_string_value')
   Assert.is_not_nil ret.j_del
   val = ret.get_value
   Assert.equals('the_string_value', val)


### PR DESCRIPTION
Fixes #29

The issue prevents from sending buffers over the event bus.